### PR TITLE
Upgrade azure-commons and other dependencies' version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>2.11</version>
-        <relativePath />
     </parent>
 
     <artifactId>kubernetes-cd</artifactId>
@@ -18,7 +18,13 @@
         <jenkins.version>1.651.3</jenkins.version>
         <java.level>7</java.level>
 
-        <azure-commons-version>0.1.5</azure-commons-version>
+        <azure-commons-version>0.2.4</azure-commons-version>
+        <credentials.version>2.1.14</credentials.version>
+        <docker-commons.version>1.10</docker-commons.version>
+        <ssh-credentials.version>1.13</ssh-credentials.version>
+        <workflow-step-api.version>2.10</workflow-step-api.version>
+
+        <kubernetes-client.version>3.1.7</kubernetes-client.version>
     </properties>
 
     <name>Kubernetes Continuous Deploy Plugin</name>
@@ -41,11 +47,11 @@
     </developers>
 
     <scm>
-      <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-      <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-      <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <repositories>
         <repository>
@@ -60,32 +66,16 @@
         </pluginRepository>
     </pluginRepositories>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.main</groupId>
-                <artifactId>jenkins-core</artifactId>
-                <version>${jenkins.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.5</version>
+            <version>${credentials.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.10</version>
+            <version>${workflow-step-api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -95,34 +85,22 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.13</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>credentials</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>${ssh-credentials.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.3.1</version>
+            <version>${docker-commons.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>azure-commons</artifactId>
             <version>${azure-commons-version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>3.0.1</version>
+            <version>${kubernetes-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/microsoft/jenkins/kubernetes/KubernetesClientWrapper.java
+++ b/src/main/java/com/microsoft/jenkins/kubernetes/KubernetesClientWrapper.java
@@ -208,7 +208,7 @@ public class KubernetesClientWrapper {
         try {
             System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "true");
             System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, filePath);
-            return Config.autoConfigure();
+            return Config.autoConfigure(null);
         } finally {
             if (originalFile == null) {
                 System.clearProperty(Config.KUBERNETES_KUBECONFIG_FILE);


### PR DESCRIPTION
It works for now, but leaving the dependencies in an ancient version will block us from removing some legacy APIs deprecated for a long time.

For example, we have done a lot of refactoring to `azure-commons` and moved the utility classes to the core library, which left the original classes in the plugin as deprecated. Eventually we need to remove them from the plugin jar, but we cannot do that if the depended plugins are not migrated to the updated version.
  