### PR TITLE
Scope for credentials lookup (#19)

### DIFF
--- a/src/main/java/com/microsoft/jenkins/kubernetes/command/DeploymentCommand.java
+++ b/src/main/java/com/microsoft/jenkins/kubernetes/command/DeploymentCommand.java
@@ -57,7 +57,7 @@ public class DeploymentCommand implements ICommand<DeploymentCommand.IDeployment
         final String defaultSecretName = jobContext.getRun().getDisplayName();
         final EnvVars envVars = context.getEnvVars();
         final boolean enableSubstitution = context.isEnableConfigSubstitution();
-        final ClientWrapperFactory clientFactory = context.clientFactory();
+        final ClientWrapperFactory clientFactory = context.clientFactory(context.getJobContext().getRun().getParent());
 
         TaskResult taskResult = null;
         try {
@@ -152,7 +152,7 @@ public class DeploymentCommand implements ICommand<DeploymentCommand.IDeployment
     }
 
     public interface IDeploymentCommand extends IBaseCommandData {
-        ClientWrapperFactory clientFactory();
+        ClientWrapperFactory clientFactory(Item owner);
 
         String getSecretNamespace();
 

--- a/src/main/java/com/microsoft/jenkins/kubernetes/credentials/ClientWrapperFactory.java
+++ b/src/main/java/com/microsoft/jenkins/kubernetes/credentials/ClientWrapperFactory.java
@@ -8,6 +8,7 @@ package com.microsoft.jenkins.kubernetes.credentials;
 
 import com.microsoft.jenkins.kubernetes.KubernetesClientWrapper;
 import hudson.FilePath;
+import hudson.model.Item;
 
 import java.io.Serializable;
 
@@ -24,6 +25,6 @@ public interface ClientWrapperFactory extends Serializable {
      * The builder that builds {@link ClientWrapperFactory}.
      */
     interface Builder {
-        ClientWrapperFactory buildClientWrapperFactory();
+        ClientWrapperFactory buildClientWrapperFactory(Item owner);
     }
 }

--- a/src/main/java/com/microsoft/jenkins/kubernetes/credentials/ConfigFileCredentials.java
+++ b/src/main/java/com/microsoft/jenkins/kubernetes/credentials/ConfigFileCredentials.java
@@ -12,6 +12,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.util.FormValidation;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -42,7 +43,7 @@ public class ConfigFileCredentials
     }
 
     @Override
-    public ClientWrapperFactory buildClientWrapperFactory() {
+    public ClientWrapperFactory buildClientWrapperFactory(Item owner) {
         return new ClientWrapperFactoryImpl(getPath());
     }
 

--- a/src/main/java/com/microsoft/jenkins/kubernetes/credentials/TextCredentials.java
+++ b/src/main/java/com/microsoft/jenkins/kubernetes/credentials/TextCredentials.java
@@ -13,6 +13,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.util.FormValidation;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -71,7 +72,7 @@ public class TextCredentials extends AbstractDescribableImpl<TextCredentials> im
     }
 
     @Override
-    public ClientWrapperFactory buildClientWrapperFactory() {
+    public ClientWrapperFactory buildClientWrapperFactory(Item owner) {
         return new ClientWrapperFactoryImpl(
                 getServerUrl(), getCertificateAuthorityData(), getClientCertificateData(), getClientKeyData());
     }

--- a/src/test/java/com/microsoft/jenkins/kubernetes/credentials/ConfigFileCredentialsTest.java
+++ b/src/test/java/com/microsoft/jenkins/kubernetes/credentials/ConfigFileCredentialsTest.java
@@ -6,12 +6,14 @@
 
 package com.microsoft.jenkins.kubernetes.credentials;
 
+import hudson.model.Item;
 import hudson.util.FormValidation;
 import org.apache.commons.lang.SerializationUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link ConfigFileCredentials}.
@@ -30,7 +32,7 @@ public class ConfigFileCredentialsTest {
     public void checkClientFactorySerialization() {
         ConfigFileCredentials credentials = new ConfigFileCredentials();
         credentials.setPath("abc");
-        ClientWrapperFactory factory = credentials.buildClientWrapperFactory();
+        ClientWrapperFactory factory = credentials.buildClientWrapperFactory(mock(Item.class));
         byte[] bytes = SerializationUtils.serialize(factory);
         Object deserialized = SerializationUtils.deserialize(bytes);
         assertTrue(deserialized instanceof ClientWrapperFactory);

--- a/src/test/java/com/microsoft/jenkins/kubernetes/credentials/SSHCredentialsTest.java
+++ b/src/test/java/com/microsoft/jenkins/kubernetes/credentials/SSHCredentialsTest.java
@@ -8,12 +8,14 @@ package com.microsoft.jenkins.kubernetes.credentials;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.microsoft.jenkins.kubernetes.util.Constants;
+import hudson.model.Item;
 import hudson.util.FormValidation;
 import org.apache.commons.lang.SerializationUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -37,9 +39,9 @@ public class SSHCredentialsTest {
     @Test
     public void testClientFactorySerialization() {
         SSHCredentials credentials = spy(new SSHCredentials());
-        doReturn(mock(StandardUsernameCredentials.class)).when(credentials).getSshCredentials();
+        doReturn(mock(StandardUsernameCredentials.class)).when(credentials).getSshCredentials(any(Item.class));
         credentials.setSshServer("example.com:1234");
-        ClientWrapperFactory factory = credentials.buildClientWrapperFactory();
+        ClientWrapperFactory factory = credentials.buildClientWrapperFactory(mock(Item.class));
 
         byte[] bytes = SerializationUtils.serialize(factory);
         Object deserialized = SerializationUtils.deserialize(bytes);

--- a/src/test/java/com/microsoft/jenkins/kubernetes/credentials/TextCredentialsTest.java
+++ b/src/test/java/com/microsoft/jenkins/kubernetes/credentials/TextCredentialsTest.java
@@ -7,12 +7,14 @@
 package com.microsoft.jenkins.kubernetes.credentials;
 
 import com.microsoft.jenkins.kubernetes.util.Constants;
+import hudson.model.Item;
 import hudson.util.FormValidation;
 import org.apache.commons.lang.SerializationUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link TextCredentials}.
@@ -26,7 +28,7 @@ public class TextCredentialsTest {
         credentials.setClientCertificateData("GHIJK");
         credentials.setClientKeyData("LMN");
 
-        ClientWrapperFactory factory = credentials.buildClientWrapperFactory();
+        ClientWrapperFactory factory = credentials.buildClientWrapperFactory(mock(Item.class));
         byte[] bytes = SerializationUtils.serialize(factory);
         Object deserialized = SerializationUtils.deserialize(bytes);
         assertTrue(deserialized instanceof ClientWrapperFactory);


### PR DESCRIPTION
This fix is to address the issue #19.

When we lookup for credentials by ID, we need to take the project scope / owner into account.