### PR TITLE
Update build instructions to use jdk-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,5 +185,5 @@ You can turn off usage data collection in Manage Jenkins -> Configure System -> 
 
 Build the plugin using docker as follows:
 ````bash
-docker run --rm -it -v "$PWD":/usr/src/kubernetes-cd -v "$PWD/target:/usr/src/kubernetes-cd/target" -v "$HOME/.m2":/root/.m2 -w /usr/src/kubernetes-cd maven:3.5.4-jdk-7 mvn package
+docker run --rm -it -v "$PWD":/usr/src/kubernetes-cd -v "$PWD/target:/usr/src/kubernetes-cd/target" -v "$HOME/.m2":/root/.m2 -w /usr/src/kubernetes-cd maven:3.5.4-jdk-8 mvn package
 ````


### PR DESCRIPTION
jdk-7 fails to build, to update to use jdk-8, which is what ci.jenkins.io is using to build kubernetes-cd-plugin