### PR TITLE
Support kubernetes credentials provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,17 +16,18 @@
         <revision>2.3.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.89</jenkins.version>
         <java.level>8</java.level>
 
         <azure-commons-version>1.0.4</azure-commons-version>
-        <credentials.version>2.1.14</credentials.version>
+        <credentials.version>2.1.16</credentials.version>
         <docker-commons.version>1.10</docker-commons.version>
         <ssh-credentials.version>1.13</ssh-credentials.version>
         <workflow-step-api.version>2.10</workflow-step-api.version>
         <jackson.version>2.10.1</jackson.version>
 
         <kubernetes-client.version>7.0.0</kubernetes-client.version>
+        <kubernetes-credentials-provider.version>0.8</kubernetes-credentials-provider.version>
     </properties>
 
     <name>Kubernetes Continuous Deploy Plugin</name>
@@ -88,6 +89,22 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
             <version>${ssh-credentials.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cloudbees.jenkins.plugins</groupId>
+            <artifactId>kubernetes-credentials-provider</artifactId>
+            <version>${kubernetes-credentials-provider.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>credentials</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-jaxb-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -158,7 +175,7 @@
             <dependency>
                 <groupId>com.squareup.retrofit2</groupId>
                 <artifactId>retrofit</artifactId>
-                <version>2.6.2</version>
+                <version>2.7.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -199,6 +216,16 @@
                 <groupId>io.reactivex</groupId>
                 <artifactId>rxjava</artifactId>
                 <version>1.3.8</version>
+            </dependency>
+	    <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>jackson2-api</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>plain-credentials</artifactId>
+                <version>1.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/com/microsoft/jenkins/kubernetes/credentials/provider/KubeconfigCredentialsConverter.java
+++ b/src/main/java/com/microsoft/jenkins/kubernetes/credentials/provider/KubeconfigCredentialsConverter.java
@@ -1,0 +1,47 @@
+package com.microsoft.jenkins.kubernetes.credentials.provider;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretUtils;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.google.common.io.BaseEncoding;
+import com.microsoft.jenkins.kubernetes.credentials.KubeconfigCredentials;
+import io.fabric8.kubernetes.api.model.Secret;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * SecretToCredentialConvertor that converts {@link KubeconfigCredentials}.
+ */
+
+@OptionalExtension(requirePlugins = {"kubernetes-credentials-provider"})
+public class KubeconfigCredentialsConverter extends SecretToCredentialConverter {
+    @Override
+    public boolean canConvert(String type) {
+        return "kubeconfig".equals(type);
+    }
+
+    @Override
+    public KubeconfigCredentials convert(Secret secret) throws CredentialsConvertionException {
+        String textBase64 = SecretUtils.getNonNullSecretData(secret, "kubeconfig", "kubeconfig is empty");
+        String secretText;
+        try {
+            secretText = new String(BaseEncoding.base64().decode(textBase64), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            throw new CredentialsConvertionException(
+                    "kubeconfig credential has an invalid text (must be base64 encoded UTF-8)", ex);
+        }
+        return new KubeconfigCredentials(
+                CredentialsScope.GLOBAL,
+                SecretUtils.getCredentialId(secret),
+                SecretUtils.getCredentialDescription(secret), new KubeconfigCredentials.KubeconfigSource() {
+            @Nonnull
+            @Override
+            public String getContent() {
+                return secretText;
+            }
+        });
+    }
+}

--- a/src/test/java/com/microsoft/jenkins/kubernetes/credentials/provider/KubeconfigCredentialsConverterTest.java
+++ b/src/test/java/com/microsoft/jenkins/kubernetes/credentials/provider/KubeconfigCredentialsConverterTest.java
@@ -1,0 +1,112 @@
+package com.microsoft.jenkins.kubernetes.credentials.provider;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.microsoft.jenkins.kubernetes.credentials.KubeconfigCredentials;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
+
+public class KubeconfigCredentialsConverterTest {
+	String content = "Hello World!";
+
+	@Test
+	public void canConvert() throws Exception {
+		KubeconfigCredentialsConverter convertor = new KubeconfigCredentialsConverter();
+		assertThat("correct registration of valid type", convertor.canConvert("kubeconfig"), is(true));
+		assertThat("incorrect type is rejected", convertor.canConvert("something"), is(false));
+	}
+
+	@Test
+	public void canConvertAValidSecret() throws Exception {
+		KubeconfigCredentialsConverter convertor = new KubeconfigCredentialsConverter();
+
+		try (InputStream is = get("valid.yaml")) {
+			Secret secret = Serialization.unmarshal(is, Secret.class);
+			assertThat("The Secret was loaded correctly from disk", notNullValue());
+			KubeconfigCredentials credential = convertor.convert(secret);
+			assertThat(credential, notNullValue());
+			assertThat("credential id is mapped correctly", credential.getId(), is("a-test-kubeconfig"));
+			assertThat("credential description is mapped correctly", credential.getDescription(), is("kubeconfig credential from Kubernetes"));
+			assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+			assertThat("credential content is mapped correctly", credential.getContent(), is(content));
+		}
+	}
+
+
+	@Test
+	public void canConvertAValidMappedSecret() throws Exception {
+		KubeconfigCredentialsConverter convertor = new KubeconfigCredentialsConverter();
+
+		try (InputStream is = get("validMapped.yaml")) {
+			Secret secret = Serialization.unmarshal(is, Secret.class);
+			assertThat("The Secret was loaded correctly from disk", notNullValue());
+			KubeconfigCredentials credential = convertor.convert(secret);
+			assertThat(credential, notNullValue());
+			assertThat("credential id is mapped correctly", credential.getId(), is("another-test-kubeconfig"));
+			assertThat("credential description is mapped correctly", credential.getDescription(), is("kubeconfig credential from Kubernetes"));
+			assertThat("credential scope is mapped correctly", credential.getScope(), is(CredentialsScope.GLOBAL));
+			assertThat("credential content is mapped correctly", credential.getContent(), is(content));
+		}
+	}
+
+
+	@Test
+	public void failsToConvertWhenDataKeyMissing() throws Exception {
+		KubeconfigCredentialsConverter convertor = new KubeconfigCredentialsConverter();
+
+		try (InputStream is = get("missingData.yaml")) {
+			Secret secret = Serialization.unmarshal(is, Secret.class);
+			convertor.convert(secret);
+			fail("Exception should have been thrown");
+		} catch (CredentialsConvertionException cex) {
+			assertThat(cex.getMessage(), containsString("kubeconfig is empty"));
+		}
+	}
+
+
+	// BASE64 Corrupt
+	@Test
+	public void failsToConvertWhenDataKeyCorrupt() throws Exception {
+		KubeconfigCredentialsConverter convertor = new KubeconfigCredentialsConverter();
+
+		try (InputStream is = get("corruptData.yaml")) {
+			Secret secret = Serialization.unmarshal(is, Secret.class);
+			convertor.convert(secret);
+			fail("Exception should have been thrown");
+		} catch (CredentialsConvertionException cex) {
+			assertThat(cex.getMessage(), containsString("kubeconfig credential has an invalid text (must be base64 encoded UTF-8)"));
+		}
+	}
+
+
+	@Test
+	public void failsToConvertWhenDataEmpty() throws Exception {
+		KubeconfigCredentialsConverter convertor = new KubeconfigCredentialsConverter();
+
+		try (InputStream is = get("void.yaml")) {
+			Secret secret = Serialization.unmarshal(is, Secret.class);
+			convertor.convert(secret);
+			fail("Exception should have been thrown");
+		} catch (CredentialsConvertionException cex) {
+			assertThat(cex.getMessage(), containsString("kubeconfig is empty"));
+		}
+	}
+
+
+	private static final InputStream get(String resource) {
+
+		InputStream is = KubeconfigCredentialsConverterTest.class.getResourceAsStream(resource);
+		if (is == null) {
+			fail("failed to load resource " + resource);
+		}
+		return is;
+	}
+
+}

--- a/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/corruptData.yaml
+++ b/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/corruptData.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-kubeconfig"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "kubeconfig"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "kubeconfig credential from Kubernetes"
+type: Opaque
+data:
+# base64 encoded bytes
+  kubeconfig: bogus # Hello World!

--- a/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/missingData.yaml
+++ b/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/missingData.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # this is the jenkins id.
+  name: "a-test-kubeconfig"
+  labels:
+    # so we know what type it is.
+    "jenkins.io/credentials-type": "kubeconfig"
+  annotations:
+    # description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "kubeconfig credential from Kubernetes"
+type: Opaque
+data:
+  blah: null

--- a/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/valid.yaml
+++ b/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/valid.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-kubeconfig"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "kubeconfig"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "kubeconfig credential from Kubernetes"
+type: Opaque
+data:
+# base64 encoded bytes
+  kubeconfig: SGVsbG8gV29ybGQh # Hello World!

--- a/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/validMapped.yaml
+++ b/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/validMapped.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "another-test-kubeconfig"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "kubeconfig"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "kubeconfig credential from Kubernetes"
+    # map the data field to stuff
+    "jenkins.io/credentials-keybinding-kubeconfig" : "stuff"
+type: Opaque
+data:
+# base64 encoded bytes
+  stuff: SGVsbG8gV29ybGQh # Hello World!

--- a/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/void.yaml
+++ b/src/test/resources/com/microsoft/jenkins/kubernetes/credentials/provider/void.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id.
+  name: "a-test-kubeconfig"
+  labels:
+# so we know what type it is.
+    "jenkins.io/credentials-type": "kubeconfig"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "kubeconfig credential from Kubernetes"
+type: Opaque
+data:
+  kubeconfig:


### PR DESCRIPTION
Add an OptionalExtension to support [Kubernetes credentials provider plugin](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/).
With this extension, the user can use a Kubernetes secret to save the kubeconfig content.

I have to upgrade the Jenkins and some plugins version to run the tests because of the kubernetes credentials provider. 

The kubernetes credentials provider plugin is optional, so this change doesn't affect the users without it.

I test the code on my Jenkins instance with and without kubernetes credentials provider by both pipeline and freestyle jobs. All jobs work as expected without error.

I will file a new pull request about the document after this one is accepted.

Thanks