### PR TITLE
Use Github as source of documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <name>Kubernetes Continuous Deploy Plugin</name>
     <description>A Jenkins plugin to deploy configurations to Kubernetes cluster.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Continuous+Deploy+Plugin</url>
+    <url>https://github.com/jenkinsci/kubernetes-cd-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
Load documentation from Github instead of the wiki.

Related tickets:
https://issues.jenkins-ci.org/browse/WEBSITE-406
https://issues.jenkins-ci.org/browse/JENKINS-59172

More info: https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/